### PR TITLE
Inject styles at closest document

### DIFF
--- a/src/utilities/__tests__/components.test.js
+++ b/src/utilities/__tests__/components.test.js
@@ -1,4 +1,10 @@
-import { getComponentName } from '../components'
+import React from 'react'
+import { mount } from 'enzyme'
+import {
+  fastGetReactDOMNode,
+  getClosestDocument,
+  getComponentName
+} from '../components'
 
 describe('getComponentName', () => {
   test('Returns component by default', () => {
@@ -11,5 +17,48 @@ describe('getComponentName', () => {
 
   test('Returns name, if available', () => {
     expect(getComponentName({ name: 'B' })).toBe('B')
+  })
+})
+
+describe('fastGetReactDOMNode', () => {
+  test('Returns node element from a React component', () => {
+    const spy = jest.fn()
+    class Button extends React.Component {
+      componentDidMount () {
+        spy(fastGetReactDOMNode(this))
+      }
+
+      render () {
+        return (<button />)
+      }
+    }
+
+    const wrapper = mount(<Button />)
+    const el = wrapper.find('button')
+
+    expect(spy).toHaveBeenCalledWith(el.node)
+  })
+})
+
+describe('getClosestDocument', () => {
+  test('Returns document element from a React component', () => {
+    const spy = jest.fn()
+    class Button extends React.Component {
+      componentDidMount () {
+        spy(getClosestDocument(this))
+      }
+
+      render () {
+        return (<button />)
+      }
+    }
+
+    mount(<Button />)
+
+    expect(spy).toHaveBeenCalledWith(global.document)
+  })
+
+  test('Falls back to document without args', () => {
+    expect(getClosestDocument()).toBe(global.document)
   })
 })

--- a/src/utilities/__tests__/styleTag.test.js
+++ b/src/utilities/__tests__/styleTag.test.js
@@ -1,4 +1,7 @@
+import React from 'react'
+import { mount } from 'enzyme'
 import {
+  getStyleTag,
   makeStyleTag
 } from '../styleTag'
 
@@ -9,5 +12,26 @@ describe('makeStyleTag', () => {
     const tag = makeStyleTag()
 
     expect(document.head.querySelector('style')).toBe(tag)
+  })
+})
+
+describe('getStyleTag', () => {
+  test('Adds a <style> tag, based on a Components relative document', () => {
+    // Clear it
+    document.head.innerHTML = ''
+    const spy = jest.fn()
+    class Button extends React.Component {
+      componentDidMount () {
+        spy(getStyleTag(this))
+      }
+
+      render () {
+        return (<button />)
+      }
+    }
+
+    mount(<Button />)
+
+    expect(spy).toHaveBeenCalledWith(document.head.querySelector('style'))
   })
 })

--- a/src/utilities/components.js
+++ b/src/utilities/components.js
@@ -9,3 +9,28 @@ export const getComponentName = (Component = {}) => (
   Component.name ||
   'Component'
 )
+
+/**
+ * Attempts to return the mounted node, based on React's internals.
+ * Currently works on React v15.
+ *
+ * @param   {object} React.Component
+ * @returns {NodeElement}
+ */
+export const fastGetReactDOMNode = (Component) => (
+  Component &&
+  Component._reactInternalInstance &&
+  Component._reactInternalInstance._renderedComponent &&
+  Component._reactInternalInstance._renderedComponent._hostNode
+)
+
+/**
+ * Gets the closest document Node.
+ *
+ * @param   {object} React.Component
+ * @returns {NodeElement}
+ */
+export const getClosestDocument = Component => {
+  const node = fastGetReactDOMNode(Component)
+  return node ? node.ownerDocument : document
+}

--- a/src/utilities/styleTag.js
+++ b/src/utilities/styleTag.js
@@ -1,16 +1,18 @@
 import { ID } from '../constants/id'
+import { getClosestDocument } from '../utilities/components'
 
 /**
  * Creates the <style> tag, and adds it to the <head>.
  *
  * @returns {NodeElement} <style>
  */
-export const makeStyleTag = () => {
-  const tag = document.createElement('style')
+export const makeStyleTag = (documentTarget) => {
+  const documentNode = documentTarget || document
+  const tag = documentNode.createElement('style')
   tag.id = ID
   tag.type = 'text/css'
 
-  const head = document.getElementsByTagName('head')[0]
+  const head = documentNode.getElementsByTagName('head')[0]
   /* istanbul ignore else */
   if (head) head.append(tag)
 
@@ -20,9 +22,15 @@ export const makeStyleTag = () => {
 /**
  * Retrieves the withStyle <style> tag.
  *
+ * @param   {object} React.Component
  * @returns {NodeElement} <style>
  */
-export const getStyleTag = () => {
-  const tag = document.getElementById(ID)
-  return tag || makeStyleTag()
+export const getStyleTag = (Component) => {
+  /* istanbul ignore next */
+  const documentNode = Component
+    ? getClosestDocument(Component)
+    : document
+
+  const tag = documentNode.getElementById(ID)
+  return tag || makeStyleTag(documentNode)
 }

--- a/src/withStyles/index.js
+++ b/src/withStyles/index.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react'
 import Style from './Style'
-import {
-  getStyleTag
-} from '../utilities/styleTag'
+import { getStyleTag } from '../utilities/styleTag'
 import { getComponentName } from '../utilities/components'
 import makeStyleSheet from '../StyleSheet/index'
 
@@ -27,13 +25,14 @@ const withStyles = (styles, options = defaultOptions) => Composed => {
       super(props)
       this.state = options
       this.styleSheet = STYLESHEET
+      this.tagNode = null
     }
 
     componentDidMount () {
       if (!id || !CSSRules || this.styleSheet.hasRule(id)) return
 
       const cssStyles = this.makeStyles()
-      const tagNode = getStyleTag()
+      const tagNode = this.getTagNode()
       tagNode.innerHTML += cssStyles
 
       this.styleSheet.addRule(id, cssStyles)
@@ -57,10 +56,17 @@ const withStyles = (styles, options = defaultOptions) => Composed => {
       const nextStyles = this.makeStyles()
       if (prevStyles === nextStyles) return
 
-      const tagNode = getStyleTag()
+      const tagNode = this.getTagNode()
       tagNode.innerHTML = tagNode.innerHTML.replace(prevStyles, nextStyles)
 
       this.styleSheet.addRule(id, nextStyles)
+    }
+
+    getTagNode () {
+      if (this.tagNode) return this.tagNode
+      this.tagNode = getStyleTag(this)
+
+      return this.tagNode
     }
 
     makeStyles () {


### PR DESCRIPTION
## Inject styles at closest document

This update enhances withStyles to more reliably target and inject it's styles
at a components closest document node (by default). This improves reliability
of component styles rendering for use with iFrames.