### PR TITLE
Fix: CSS parsing with space between selectors

### DIFF
--- a/src/utilities/__tests__/classNames.test.js
+++ b/src/utilities/__tests__/classNames.test.js
@@ -107,4 +107,20 @@ describe('makeUniqSelector', () => {
 
     expect(makeUniqSelector('.card\\@md', uuid, id)).toBe('.card\\@md__abc-123')
   })
+
+  test('Returns uniq selector for classNames with nested selectors', () => {
+    expect(makeUniqSelector('.a .b .c', uuid, id)).toBe('.a__abc-123 .b .c')
+  })
+
+  test('Returns uniq selector for classNames with commas', () => {
+    expect(makeUniqSelector('.a, .b', uuid, id)).toBe('.a__abc-123, .b')
+  })
+
+  test('Returns uniq selector for classNames with wildcard', () => {
+    expect(makeUniqSelector('.c *', uuid, id)).toBe('.c__abc-123 *')
+    expect(makeUniqSelector('* .c', uuid, id)).toBe('* .c')
+    expect(makeUniqSelector('.c > *', uuid, id)).toBe('.c__abc-123 > *')
+    expect(makeUniqSelector('.c + .c *', uuid, id)).toBe('.c__abc-123+.c__abc-123 *')
+    expect(makeUniqSelector('.c + .c > *', uuid, id)).toBe('.c__abc-123+.c__abc-123 > *')
+  })
 })

--- a/src/utilities/classNames.js
+++ b/src/utilities/classNames.js
@@ -24,6 +24,18 @@ export const classNames = (...classes) => {
 export const isClassName = selector => selector && selector.charAt(0) === '.'
 
 /**
+ * Factory function to generate unique className for first className within
+ * selector rule.
+ *
+ * @param   {string} uuid
+ * @param   {string} id
+ * @returns {string}
+ */
+export const makeUniqFirstClassName = (uuid, id) => (item, index) => {
+  return index === 0 ? `${item}__${uuid}-${id}` : item
+}
+
+/**
  * Creates a unique namespaced className selector.
  *
  * @param   {string} selector
@@ -32,9 +44,27 @@ export const isClassName = selector => selector && selector.charAt(0) === '.'
  * @returns {string}
  */
 export const makeUniqClassName = (selector, uuid, id) => {
-  return selector.split(':')
-    .map((s, index) => index === 0 ? `${s}__${uuid}-${id}` : s)
-    .join(':')
+  const generateClassName = makeUniqFirstClassName(uuid, id)
+
+  const generate = (item, index) => {
+    let className = generateClassName(item, index)
+
+    if (index === 0) {
+      if (item.indexOf(':') >= 0) {
+        className = item.split(':').map(generateClassName).join(':')
+      }
+      if (item.indexOf(',') >= 0) {
+        className = item.split(',').map(generateClassName).join(',')
+      }
+    }
+
+    return className
+  }
+
+  return selector
+    .split(' ')
+    .map(generate)
+    .join(' ')
 }
 
 /**


### PR DESCRIPTION
## Fix: CSS parsing with space between selectors

This update fixes the CSS parser to allow for rules like `.Card > *` to
properly generate unique styles.