### PR TITLE
Fix: Chained className unique hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A simple way to include CSS with React Components.
 
-* **Tiny**, around 1.5 KB gzipped
+* **Tiny**, around 1.6 KB gzipped
 * **One dependency** - ([Stylis](https://github.com/thysultan/stylis.js))
 * **Write** plain ol' CSS. Period.
 * **Pre-processing** when you need it. Powered by [Stylis](https://github.com/thysultan/stylis.js).

--- a/src/utilities/__tests__/classNames.test.js
+++ b/src/utilities/__tests__/classNames.test.js
@@ -116,6 +116,12 @@ describe('makeUniqSelector', () => {
     expect(makeUniqSelector('.a, .b', uuid, id)).toBe('.a__abc-123, .b')
   })
 
+  test('Returns uniq selector for chained classNames', () => {
+    expect(makeUniqSelector('.a.b.c', uuid, id)).toBe('.a__abc-123.b.c')
+    expect(makeUniqSelector('.a.b .c', uuid, id)).toBe('.a__abc-123.b .c')
+    expect(makeUniqSelector('.a.is-awesome .a__child', uuid, id)).toBe('.a__abc-123.is-awesome .a__child')
+  })
+
   test('Returns uniq selector for classNames with wildcard', () => {
     expect(makeUniqSelector('.c *', uuid, id)).toBe('.c__abc-123 *')
     expect(makeUniqSelector('* .c', uuid, id)).toBe('* .c')

--- a/src/utilities/classNames.js
+++ b/src/utilities/classNames.js
@@ -1,7 +1,5 @@
-import {
-  DELIMETER,
-  SEP
-} from '../constants/stylis'
+import { DELIMETER, SEP } from '../constants/stylis'
+import { has, hasMany } from './strings'
 
 /**
  * Returns an array of classNames prepped for React.
@@ -43,8 +41,8 @@ export const makeUniqFirstClassName = (uuid, id) => (item, index) => {
  * @param   {function} compiler
  * @returns {string}
  */
-export const compileRule = (rule, token, compiler) => {
-  return rule.split(token).map(compiler).join(token)
+export const compileRule = (rule, token, compiler, prefix = '', suffix = '') => {
+  return prefix + rule.split(token).filter(r => r).map(compiler).join(token) + suffix
 }
 
 /**
@@ -62,11 +60,14 @@ export const makeUniqClassName = (selector, uuid, id) => {
     let className = generateClassName(item, index)
 
     if (index === 0) {
-      if (item.indexOf(':') >= 0) {
+      if (hasMany(item, /\./)) {
+        className = compileRule(item, '.', generateClassName, '.')
+      }
+      if (has(item, ':')) {
         className = compileRule(item, ':', generateClassName)
       }
-      if (item.indexOf(',') >= 0) {
-        className = compileRule(item, ',', generateClassName)
+      if (has(item, ',')) {
+        className = compileRule(item, ',', generateClassName, '', ',')
       }
     }
 

--- a/src/utilities/strings.js
+++ b/src/utilities/strings.js
@@ -1,0 +1,29 @@
+/**
+ * Determines the amount of occurances of a sub-string is within a string.
+ *
+ * @param   {string} string
+ * @param   {regex} regex
+ * @returns {number}
+ */
+export const checkOccurance = (string, regex) => {
+  const match = string.match(new RegExp(regex, 'gi'))
+  return match ? match.length : 0
+}
+
+/**
+ * Determines if string contains multiple sub-strings.
+ *
+ * @param   {string} string
+ * @param   {regex} regex
+ * @returns {bool}
+ */
+export const hasMany = (string, regex) => checkOccurance(string, regex) > 1
+
+/**
+ * Determines if string contains at least one occurance of sub-string.
+ *
+ * @param   {string} string
+ * @param   {regex} regex
+ * @returns {bool}
+ */
+export const has = (string, regex) => checkOccurance(string, regex) > 0


### PR DESCRIPTION
## Fix: Chained className unique hashing

This update fixes the unique hashing for chained classNames like:

```
.Card.is-big
```

Which should resolve to:

```
.Card__j1hdj1-1.is-big
```

Resolves: https://github.com/helpscout/fancy/issues/10