### PR TITLE
Fix: Replace append with appendChild

### DIFF
--- a/src/utilities/styleTag.js
+++ b/src/utilities/styleTag.js
@@ -14,7 +14,7 @@ export const makeStyleTag = (documentTarget) => {
 
   const head = documentNode.getElementsByTagName('head')[0]
   /* istanbul ignore else */
-  if (head) head.append(tag)
+  if (head) head.appendChild(tag)
 
   return tag
 }


### PR DESCRIPTION
## Fix: Replace append with appendChild 🌏

![screen shot 2018-05-07 at 4 40 35 pm](https://user-images.githubusercontent.com/2322354/39723966-63f8eada-5215-11e8-8e6b-7e3e284d3089.jpg)

This is for IE/Edge support. Tested on Browserstack.