### PR TITLE
Utilities: Fix attribute + className chaining

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -3,7 +3,7 @@
  */
 export const ID = '__REACT_FANCY_STYLES__'
 export const FANCY_PRIMITIVE = '__IS_TOTES_A_FANCY_PRIMITIVE__'
-export const PRIMITIVE_CLASSNAME = 'fancy'
+export const PRIMITIVE_CLASSNAME = 'fs'
 
 /**
  * Stylis / Tokens

--- a/src/styled/index.js
+++ b/src/styled/index.js
@@ -1,7 +1,11 @@
 // @flow
 import React, { Component } from 'react'
 import Style from './Style'
-import { FANCY_PRIMITIVE, ELEMENT_TAGS_LIST } from '../constants'
+import {
+  FANCY_PRIMITIVE,
+  ELEMENT_TAGS_LIST,
+  PRIMITIVE_CLASSNAME,
+} from '../constants'
 import { classNames } from '../utilities/classNames'
 import { isArray, isFunction, isString } from '../utilities/is'
 import { getStyleTag } from '../utilities/styleTag'
@@ -146,7 +150,10 @@ const styled = (Composed, composedProps) => (
         ...composedProps,
         ...rest,
       }
-      const className = classNames(this.styles.fancy, this.props.className)
+      const className = classNames(
+        this.styles[PRIMITIVE_CLASSNAME],
+        this.props.className
+      )
 
       return isString(Composed) ? (
         React.createElement(Composed, {

--- a/src/utilities/__tests__/classNames.test.js
+++ b/src/utilities/__tests__/classNames.test.js
@@ -187,6 +187,63 @@ describe('makeUniqSelector', () => {
       '.c__abc-123+.c__abc-123 > *'
     )
   })
+
+  test('Returns uniq selector for chained + modifier', () => {
+    expect(makeUniqSelector('.c.is-m', uuid, id)).toBe('.c__abc-123.is-m')
+    expect(makeUniqSelector('.c.is-m.is-o', uuid, id)).toBe(
+      '.c__abc-123.is-m.is-o'
+    )
+  })
+
+  test('Returns uniq selector for chained + (BEM) element', () => {
+    expect(makeUniqSelector('.c .c__el', uuid, id)).toBe('.c__abc-123 .c__el')
+  })
+
+  test('Returns uniq selector for [attribute]', () => {
+    expect(makeUniqSelector('.c[class*=b]', uuid, id)).toBe(
+      '.c__abc-123[class*=b]'
+    )
+    expect(makeUniqSelector('.c[class*=b] .m', uuid, id)).toBe(
+      '.c__abc-123[class*=b] .m'
+    )
+    expect(makeUniqSelector('.c[class*=b].is-m', uuid, id)).toBe(
+      '.c__abc-123[class*=b].is-m'
+    )
+  })
+
+  test('Returns uniq selector for pseudo', () => {
+    expect(makeUniqSelector('.c:hover', uuid, id)).toBe('.c__abc-123:hover')
+    expect(makeUniqSelector('.c:hover:active', uuid, id)).toBe(
+      '.c__abc-123:hover:active'
+    )
+    expect(makeUniqSelector('.c:hover:active:focus span', uuid, id)).toBe(
+      '.c__abc-123:hover:active:focus span'
+    )
+  })
+
+  test('Returns uniq selector for [attribute] and pseudo', () => {
+    expect(makeUniqSelector('.c[class*=b]:hover', uuid, id)).toBe(
+      '.c__abc-123[class*=b]:hover'
+    )
+    expect(makeUniqSelector('.c[class*=b]:hover:active', uuid, id)).toBe(
+      '.c__abc-123[class*=b]:hover:active'
+    )
+    expect(
+      makeUniqSelector('.c[class*=b]:hover:active:focus span', uuid, id)
+    ).toBe('.c__abc-123[class*=b]:hover:active:focus span')
+  })
+
+  test('Returns uniq selector for chained and [attribute] and pseudo', () => {
+    expect(makeUniqSelector('.c.b[class*=b]:hover', uuid, id)).toBe(
+      '.c__abc-123.b[class*=b]:hover'
+    )
+    expect(makeUniqSelector('.c.b[class*=b]:hover:active', uuid, id)).toBe(
+      '.c__abc-123.b[class*=b]:hover:active'
+    )
+    expect(
+      makeUniqSelector('.c.b[class*=b]:hover:active:focus span', uuid, id)
+    ).toBe('.c__abc-123.b[class*=b]:hover:active:focus span')
+  })
 })
 
 describe('makeRuleFromStylis', () => {

--- a/src/utilities/__tests__/primitives.test.js
+++ b/src/utilities/__tests__/primitives.test.js
@@ -1,4 +1,5 @@
 import { makeInterpolatedStyles, makeInterpolatedCSSRules } from '../primitives'
+import { PRIMITIVE_CLASSNAME } from '../../constants'
 
 describe('makeInterpolatedStyles', () => {
   test('Can render component (string) with string args', () => {
@@ -8,7 +9,7 @@ describe('makeInterpolatedStyles', () => {
 
     const styles = makeInterpolatedStyles(Jolteon, args, options)
 
-    expect(styles()).toContain('fancy')
+    expect(styles()).toContain(PRIMITIVE_CLASSNAME)
     expect(styles()).toContain('color: yellow')
   })
 
@@ -19,7 +20,7 @@ describe('makeInterpolatedStyles', () => {
 
     const styles = makeInterpolatedStyles(Jolteon, args, options)
 
-    expect(styles()).toContain('fancy')
+    expect(styles()).toContain(PRIMITIVE_CLASSNAME)
     expect(styles()).toContain('color: yellow')
   })
 
@@ -30,7 +31,7 @@ describe('makeInterpolatedStyles', () => {
 
     const styles = makeInterpolatedStyles(Jolteon, args, options)
 
-    expect(styles()).toContain('fancy')
+    expect(styles()).toContain(PRIMITIVE_CLASSNAME)
     expect(styles()).toContain('color: yellow')
   })
 
@@ -40,7 +41,7 @@ describe('makeInterpolatedStyles', () => {
 
     const styles = makeInterpolatedStyles(Jolteon, args)
 
-    expect(styles()).toContain('fancy')
+    expect(styles()).toContain(PRIMITIVE_CLASSNAME)
     expect(styles()).toContain('color: yellow')
   })
 })
@@ -52,7 +53,7 @@ describe('makeInterpolatedCSSRules', () => {
 
     const styles = makeInterpolatedCSSRules(Jolteon, args)
 
-    expect(styles()).toContain('fancy')
+    expect(styles()).toContain(PRIMITIVE_CLASSNAME)
     expect(styles()).toContain('color: yellow')
   })
 })

--- a/src/utilities/classNames.js
+++ b/src/utilities/classNames.js
@@ -90,13 +90,19 @@ export const makeUniqClassName = (selector, uuid, id) => {
     let className = generateClassName(item, index)
 
     if (index === 0) {
-      if (hasMany(item, /\./)) {
+      if (hasMany(item, /\./) && has(item, /\[/)) {
+        if (item.substring(1).indexOf('.') < item.indexOf('[')) {
+          className = compileRule(item, '.', generateClassName, '.')
+        } else {
+          className = compileRule(item, '[', generateClassName)
+        }
+      } else if (has(item, /\[/)) {
+        className = compileRule(item, '[', generateClassName)
+      } else if (hasMany(item, /\./)) {
         className = compileRule(item, '.', generateClassName, '.')
-      }
-      if (has(item, ':')) {
+      } else if (has(item, ':')) {
         className = compileRule(item, ':', generateClassName)
-      }
-      if (has(item, ',')) {
+      } else if (has(item, ',')) {
         className = compileRule(item, ',', generateClassName, '', ',')
       }
     }
@@ -125,6 +131,7 @@ export const makeUniqSelectorForCombinator = (
   const selectors = getPreCompileSelectors(selector, combinator)
   const compiler = (s, index) => {
     const base = getBaseSelector(s)
+
     if (index > 0 && base !== selectors[0]) return s
     return makeUniqClassName(s, uuid, id)
   }

--- a/src/utilities/id.js
+++ b/src/utilities/id.js
@@ -6,11 +6,11 @@
 export const shortUUID = () =>
   Math.random()
     .toString(36)
-    .substring(2, 5)
+    .substring(2, 9)
 
 /**
  * Generates a (short) UUID.
  *
  * @returns {string}
  */
-export const uuid = () => shortUUID() + shortUUID()
+export const uuid = () => shortUUID()

--- a/src/utilities/primitives.js
+++ b/src/utilities/primitives.js
@@ -76,7 +76,7 @@ export const makeInterpolatedCSSRules = (
 ) => {
   // Special handling in case the styles is a functional callback
   if (isFunction(args)) {
-    const className = options.className || 'fancy'
+    const className = options.className || PRIMITIVE_CLASSNAME
     return props => `.${className} { ${args(props)} }`
   } else {
     return makeInterpolatedStyles(component, args, options)

--- a/stories/primitive.stories.js
+++ b/stories/primitive.stories.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { storiesOf } from '@storybook/react'
-import styled from '../src'
+import styled from '../src/styled/index'
 import ThemeProvider from '../src/ThemeProvider'
 
 const stories = storiesOf('Primitives', module)
@@ -34,6 +34,22 @@ class Changer extends Component {
     return (
       <div>
         <Thing color={this.state.color}>
+          Another Styled <span className="span">Components</span>
+        </Thing>
+
+        <Thing title="ddd">
+          Another Styled <span className="span">Components</span>
+        </Thing>
+        <Thing>
+          Another Styled <span className="span">Components</span>
+        </Thing>
+        <Thing>
+          Another Styled <span className="span">Components</span>
+        </Thing>
+        <Thing>
+          Another Styled <span className="span">Components</span>
+        </Thing>
+        <Thing>
           Another Styled <span className="span">Components</span>
         </Thing>
         <button onClick={this.changeColor}>Change!</button>


### PR DESCRIPTION
## Utilities: Fix attribute + className chaining 💪 

This update resolves the issue of where Fancy incorrectly injects the
unique selector in the wrong spot for (more complicated) rules that involve
`[class*=""]` like attribute selectors and/or className chaining that involves
pseudo selectors.

Under updates include shortening Fancy's primitive className token,
and improving the UUID() generation function.