### PR TITLE
Hoist statics when creating styled components

### DIFF
--- a/src/create-emotion-styled/index.js
+++ b/src/create-emotion-styled/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import type {ElementType} from 'react'
 import typeof ReactType from 'react'
 import type {CreateStyled, StyledOptions} from './utils'
+import hoistNonReactStatics from '@helpscout/react-utils/dist/hoistNonReactStatics'
 import {
   themeChannel as channel,
   testPickPropsOnComponent,
@@ -265,7 +266,7 @@ function createEmotionStyled(emotion: Object, view: ReactType) {
         )(...styles)
       }
 
-      return Styled
+      return hoistNonReactStatics(Styled, baseTag)
     }
   }
   if (process.env.NODE_ENV !== 'production' && typeof Proxy !== 'undefined') {

--- a/src/create-emotion-styled/utils.js
+++ b/src/create-emotion-styled/utils.js
@@ -57,6 +57,7 @@ type BaseCreateStyled = (
 ) => CreateStyledComponent
 
 export type CreateStyled = {
+  // $FlowFixMe
   $call: BaseCreateStyled,
   [key: string]: CreateStyledComponent,
 }

--- a/src/styled/__tests__/styled.test.js
+++ b/src/styled/__tests__/styled.test.js
@@ -106,4 +106,64 @@ describe('styled', () => {
       expect(spy).toHaveBeenCalled()
     })
   })
+
+  describe('Statics', () => {
+    test('Hoists statics when created a styled-component', () => {
+      const anotherStatic = []
+      class StaticComponent extends React.Component {
+        render() {
+          return null
+        }
+      }
+      class InnerComponent extends React.Component {
+        static firstStatic = StaticComponent
+        static secondStatic = anotherStatic
+        render() {
+          return null
+        }
+      }
+      const TestComponent = styled(InnerComponent)()
+
+      expect(TestComponent.firstStatic).toBe(StaticComponent)
+      expect(TestComponent.secondStatic).toBe(anotherStatic)
+    })
+
+    test('Hoists a SFC static when created a styled-component', () => {
+      const anotherStatic = []
+      class StaticComponent extends React.Component {
+        render() {
+          return null
+        }
+      }
+      const InnerComponent = () => {
+        return null
+      }
+      InnerComponent.firstStatic = StaticComponent
+      InnerComponent.secondStatic = anotherStatic
+
+      const TestComponent = styled(InnerComponent)()
+
+      expect(TestComponent.firstStatic).toBe(StaticComponent)
+      expect(TestComponent.secondStatic).toBe(anotherStatic)
+    })
+
+    test('Hoists styled-component statics when created a styled-component', () => {
+      class StaticComponent extends React.Component {
+        render() {
+          return null
+        }
+      }
+      const StyledStaticComponent = styled(StaticComponent)()
+
+      class InnerComponent extends React.Component {
+        static StaticComponent = StyledStaticComponent
+        render() {
+          return null
+        }
+      }
+      const TestComponent = styled(InnerComponent)()
+
+      expect(TestComponent.StaticComponent).toBe(StyledStaticComponent)
+    })
+  })
 })


### PR DESCRIPTION
## Hoist statics when creating styled components

This update enhances the create-emotion-styled function to hoist
statics to the final wrapped component.