### PR TITLE
Frame/ScopeProvider: Render multiple children

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,7 @@ script:
 
 after_success:
   - npm run coverage
+
+branches:
+  only:
+    - master

--- a/src/FrameProvider/FrameProvider.js
+++ b/src/FrameProvider/FrameProvider.js
@@ -1,5 +1,5 @@
 // @flow
-import {Component, Children, type Node as ReactNode} from 'react'
+import React, {Component, Children, type Node as ReactNode} from 'react'
 import {getDocumentFromReactComponent} from '../utils'
 import createBroadcast from './createBroadcast'
 import {channel, contextTypes} from './utils'
@@ -37,10 +37,13 @@ class FrameProvider extends Component<Props> {
   }
 
   render() {
-    if (!this.props.children) {
-      return null
-    }
-    return Children.only(this.props.children)
+    const {children} = this.props
+    const childCount = Children.count(children)
+
+    if (childCount === 0) return null
+    if (childCount === 1) return children
+
+    return <div className="FancyFrameProvider">{children}</div>
   }
 }
 

--- a/src/FrameProvider/__tests__/FrameProvider.test.js
+++ b/src/FrameProvider/__tests__/FrameProvider.test.js
@@ -16,6 +16,28 @@ describe('FrameProvider', () => {
     expect(wrapper.instance()).toBeTruthy()
   })
 
+  test('Can render a single child', () => {
+    const wrapper = mount(
+      <FrameProvider>
+        <div />
+      </FrameProvider>,
+    )
+
+    expect(wrapper.instance()).toBeTruthy()
+  })
+
+  test('Can render a multiple children', () => {
+    const wrapper = mount(
+      <FrameProvider>
+        <div />
+        <div />
+        <div />
+      </FrameProvider>,
+    )
+
+    expect(wrapper.instance()).toBeTruthy()
+  })
+
   test('Does not affect styles if no iFrame is present', () => {
     const Compo = styled('span')`
       color: red;

--- a/src/ScopeProvider/ScopeProvider.js
+++ b/src/ScopeProvider/ScopeProvider.js
@@ -1,5 +1,5 @@
 // @flow
-import {Component, Children, type Node as ReactNode} from 'react'
+import React, {Component, Children, type Node as ReactNode} from 'react'
 import PropTypes from 'prop-types'
 import channel from './channel'
 
@@ -22,10 +22,13 @@ class ScopeProvider extends Component<Props> {
   }
 
   render() {
-    if (!this.props.children) {
-      return null
-    }
-    return Children.only(this.props.children)
+    const {children} = this.props
+    const childCount = Children.count(children)
+
+    if (childCount === 0) return null
+    if (childCount === 1) return children
+
+    return <div className="FancyScopeProvider">{children}</div>
   }
 }
 

--- a/src/ScopeProvider/__tests__/ScopeProvider.test.js
+++ b/src/ScopeProvider/__tests__/ScopeProvider.test.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import {mount} from 'enzyme'
 import styled from '../../styled/index'
 import ScopeProvider from '../index'
 import ThemeProvider from '../../ThemeProvider'
-import { getStyleProp, resetStyleTags } from '../../utils/testHelpers'
+import {getStyleProp, resetStyleTags} from '../../utils/testHelpers'
 
 describe('ScopeProvider', () => {
   afterEach(() => {
@@ -13,6 +13,28 @@ describe('ScopeProvider', () => {
   describe('Basic', () => {
     test('Can render without children', () => {
       const wrapper = mount(<ScopeProvider />)
+
+      expect(wrapper.instance()).toBeTruthy()
+    })
+
+    test('Can render a single child', () => {
+      const wrapper = mount(
+        <ScopeProvider>
+          <div />
+        </ScopeProvider>,
+      )
+
+      expect(wrapper.instance()).toBeTruthy()
+    })
+
+    test('Can render a multiple children', () => {
+      const wrapper = mount(
+        <ScopeProvider>
+          <div />
+          <div />
+          <div />
+        </ScopeProvider>,
+      )
 
       expect(wrapper.instance()).toBeTruthy()
     })
@@ -27,7 +49,7 @@ describe('ScopeProvider', () => {
           <div id="app">
             <Compo />
           </div>
-        </ScopeProvider>
+        </ScopeProvider>,
       )
       const el = wrapper.find('span').getNode()
 
@@ -46,7 +68,7 @@ describe('ScopeProvider', () => {
               <Compo />
             </div>
           </div>
-        </ScopeProvider>
+        </ScopeProvider>,
       )
       const el = wrapper.find('span').getNode()
       const html = document.head.innerHTML
@@ -65,7 +87,7 @@ describe('ScopeProvider', () => {
           <ScopeProvider scope="#app">
             <Compo />
           </ScopeProvider>
-        </div>
+        </div>,
       )
       const el = wrapper.find('span').getNode()
 
@@ -85,7 +107,7 @@ describe('ScopeProvider', () => {
               <Compo />
             </ScopeProvider>
           </div>
-        </div>
+        </div>,
       )
       const first = wrapper
         .find('span')
@@ -119,7 +141,7 @@ describe('ScopeProvider', () => {
               </ScopeProvider>
             </ScopeProvider>
           </div>
-        </div>
+        </div>,
       )
 
       const el = wrapper.find('span').getNode()
@@ -146,12 +168,12 @@ describe('ScopeProvider', () => {
         <div className="body">
           <div id="app">
             <ScopeProvider scope=".body">
-              <ThemeProvider theme={{ color: 'red' }}>
+              <ThemeProvider theme={{color: 'red'}}>
                 <Compo />
               </ThemeProvider>
             </ScopeProvider>
           </div>
-        </div>
+        </div>,
       )
 
       const el = wrapper.find('span').getNode()


### PR DESCRIPTION
## Frame/ScopeProvider: Render multiple children

This update enhances the Frame/ScopeProviders to allow them to render
multiple children. If more than one child component is passed, a `div`
wrapper will be rendered. This is essentially a work-around to
React.Fragments, which isn't available in React 15.