### PR TITLE
Scope: CSS Extend fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/fancy",
-  "version": "2.0.6",
+  "version": "2.1.0-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@helpscout/fancy",
   "private": false,
-  "version": "2.0.6",
+  "version": "2.1.0-2",
   "description": "A simple way to include CSS with React Components",
   "main": "dist/index.js",
   "scripts": {

--- a/src/create-emotion/index.js
+++ b/src/create-emotion/index.js
@@ -307,15 +307,14 @@ function createEmotion(
         ? `${scope.replace(/ /g, '-')}-${selector}`
         : selector
 
-      if (caches.registered[namespace] === undefined) {
-        caches.registered[namespace] = stylesWithLabel
+      if (caches.registered[selector] === undefined) {
+        caches.registered[selector] = stylesWithLabel
       }
       const scopeSelector = scope ? scope.concat(' ') : ''
       insert(`${scopeSelector}.${selector}`, styles, namespace)
 
       return selector
     }
-
   const keyframes: CreateStyles<string> = function keyframes() {
     const styles = createStyles.apply(this, arguments)
     const animation = `animation-${name}`

--- a/stories/CardCo.js
+++ b/stories/CardCo.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import getValidProps from '@helpscout/react-utils/dist/getValidProps'
+import propConnect from '@helpscout/blue/components/PropProvider/propConnect'
+import {namespaceComponent} from '@helpscout/blue/utilities/component'
+import styled, {ScopeProvider} from '../src'
+import classNames from '@helpscout/blue/utilities/classNames'
+
+const CardUI = styled('div')`
+  padding: 50px;
+  background: blue;
+`
+
+class CardCo extends React.Component {
+  render() {
+    const {...rest} = this.props
+    return <CardUI {...rest} />
+  }
+}
+
+namespaceComponent('CardCo')(CardCo)
+
+export default propConnect('Card')(CardCo)

--- a/stories/HOC.stories.js
+++ b/stories/HOC.stories.js
@@ -1,0 +1,60 @@
+import React from 'react'
+import {storiesOf} from '@storybook/react'
+import propConnect from '@helpscout/blue/components/PropProvider/propConnect'
+import {namespaceComponent} from '@helpscout/blue/utilities/component'
+import styled, {ScopeProvider} from '../src'
+import Card from './CardCo'
+
+const stories = storiesOf('HOC', module)
+
+const StyledCard = styled(Card)`
+  padding: 0px;
+  background: red;
+`
+
+const Thing = styled('div')`
+  padding: 20px;
+`
+
+class Test extends React.Component {
+  componentDidMount() {
+    const cardNode = document.querySelector('.card')
+    const styledCardNode = document.querySelector('.styledCard')
+
+    const a = cardNode.classList.length
+    const l = styledCardNode.classList.length
+
+    this.node.innerHTML = `
+      ✅ PASS: cardNode: ${a};<br /><br />
+      ${l === a ? '✅ PASS' : '🔥 FAIL'}: styledCardNode: ${l};<br /><br />
+      <hr />
+      ${cardNode.classList.toString()}
+      <hr />
+      ${styledCardNode.classList.toString()}
+      <hr />
+    `
+  }
+  render() {
+    return (
+      <ScopeProvider scope="#APP">
+        <div id="APP">
+          <div ref={node => (this.node = node)} />
+          <Card className="card" innerRef={node => (this.cardNode = node)}>
+            Card
+          </Card>
+          <StyledCard
+            className="styledCard"
+            innerRef={node => (this.styledCardNode = node)}
+          >
+            StyledCard
+          </StyledCard>
+          <Thing innerRef={node => (this.thingNode = node)}>Thing</Thing>
+        </div>
+      </ScopeProvider>
+    )
+  }
+}
+
+stories.add('Example', () => {
+  return <Test />
+})


### PR DESCRIPTION
## Scope: CSS Extend fix

This update fixes the styled(Component) extending functionality with Emotion.

The issue was that the cssWithScope function was comparing the SCOPED namespace
rather than the CSS selector. This wasn't compatible with Emotion's
cache consolidator, which resulted in scoped classes NOT being able to be
extended.

Some very crude tests.

Before:

![screen shot 2018-10-12 at 9 36 20 pm](https://user-images.githubusercontent.com/2322354/46900146-b2b79b80-ce6b-11e8-83e6-fbb01182af8c.jpg)

After:

![screen shot 2018-10-12 at 9 33 59 pm](https://user-images.githubusercontent.com/2322354/46900149-b814e600-ce6b-11e8-92cc-038401ea1335.jpg)

Notice how in the After pic, both lines only have 2 classes, whereas the Before pic, it was 2 and 3.

Resolves: https://github.com/helpscout/fancy/issues/27