### PR TITLE
Theme custom prop

### DIFF
--- a/src/ThemeProvider/__tests__/ThemeProvider.test.js
+++ b/src/ThemeProvider/__tests__/ThemeProvider.test.js
@@ -1,8 +1,8 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import {mount} from 'enzyme'
 import styled from '../../styled/index'
 import ThemeProvider from '../index'
-import { getStyleProp, resetStyleTags } from '../../utils/testHelpers'
+import {getStyleProp, resetStyleTags} from '../../utils/testHelpers'
 
 describe('ThemeProvider', () => {
   afterEach(() => {
@@ -21,7 +21,7 @@ describe('ThemeProvider', () => {
       const wrapper = mount(
         <ThemeProvider theme={theme}>
           <Compo />
-        </ThemeProvider>
+        </ThemeProvider>,
       )
       const el = wrapper.find('span').getNode()
 
@@ -41,7 +41,7 @@ describe('ThemeProvider', () => {
       const wrapper = mount(
         <ThemeProvider theme={theme}>
           <Compo />
-        </ThemeProvider>
+        </ThemeProvider>,
       )
       const el = wrapper.find('span').getNode()
 
@@ -59,7 +59,7 @@ describe('ThemeProvider', () => {
       const wrapper = mount(
         <ThemeProvider theme={theme}>
           <Compo />
-        </ThemeProvider>
+        </ThemeProvider>,
       )
       wrapper.setProps({
         theme: {
@@ -79,11 +79,11 @@ describe('ThemeProvider', () => {
       `
 
       const wrapper = mount(
-        <ThemeProvider theme={{ color: 'red' }}>
-          <ThemeProvider theme={{ backgroundColor: 'blue' }}>
+        <ThemeProvider theme={{color: 'red'}}>
+          <ThemeProvider theme={{backgroundColor: 'blue'}}>
             <Compo />
           </ThemeProvider>
-        </ThemeProvider>
+        </ThemeProvider>,
       )
       const el = wrapper.find('span').getNode()
 
@@ -96,15 +96,65 @@ describe('ThemeProvider', () => {
       `
 
       const wrapper = mount(
-        <ThemeProvider theme={{ color: 'blue' }}>
-          <ThemeProvider theme={{ color: 'red' }}>
+        <ThemeProvider theme={{color: 'blue'}}>
+          <ThemeProvider theme={{color: 'red'}}>
             <Compo />
           </ThemeProvider>
-        </ThemeProvider>
+        </ThemeProvider>,
       )
       const el = wrapper.find('span').getNode()
 
       expect(getStyleProp(el, 'color')).toBe('red')
+    })
+  })
+
+  describe('Custom theme prop', () => {
+    test('Defining a custom theme prop, overrides ThemeProvider', () => {
+      // Define our button
+      const Button = styled('button')`
+        font-size: 1em;
+        margin: 1em;
+        padding: 0.25em 1em;
+        border-radius: 3px;
+
+        /* Color the border and text with theme.main */
+        color: ${props => props.theme.main};
+        border: 2px solid ${props => props.theme.main};
+      `
+
+      // Define what main theme will look like
+      const theme = {
+        main: 'green',
+      }
+
+      const wrapper = mount(
+        <div>
+          <Button theme={{main: 'blue'}} className="adhoc">
+            Ad hoc theme
+          </Button>
+          <ThemeProvider theme={theme}>
+            <div>
+              <Button className="themed">Themed</Button>
+              <Button theme={{main: 'red'}} className="overridden">
+                Overidden
+              </Button>
+            </div>
+          </ThemeProvider>
+        </div>,
+      )
+
+      const adhocNode = wrapper.find('button.adhoc').getNode()
+      const themedNode = wrapper.find('button.themed').getNode()
+      const overriddenNode = wrapper.find('button.overridden').getNode()
+
+      expect(getStyleProp(adhocNode, 'color')).toBe('blue')
+      expect(getStyleProp(adhocNode, 'border')).toContain('blue')
+
+      expect(getStyleProp(themedNode, 'color')).toBe('green')
+      expect(getStyleProp(themedNode, 'border')).toContain('green')
+
+      expect(getStyleProp(overriddenNode, 'color')).toBe('red')
+      expect(getStyleProp(overriddenNode, 'border')).toContain('red')
     })
   })
 })

--- a/src/create-emotion-styled/index.js
+++ b/src/create-emotion-styled/index.js
@@ -171,7 +171,7 @@ function createEmotionStyled(emotion: Object, view: ReactType) {
         render() {
           const {props, state} = this
           this.mergedProps = pickAssign(testAlwaysTrue, {}, props, {
-            theme: (state !== null && state.theme) || props.theme || {},
+            theme: props.theme || (state !== null && state.theme) || {},
           })
 
           let className = ''

--- a/stories/styled-components/01-getting-started.stories.js
+++ b/stories/styled-components/01-getting-started.stories.js
@@ -1,0 +1,241 @@
+import React from 'react'
+import {storiesOf} from '@storybook/react'
+import styled, {keyframes} from '../../src/index'
+
+const stories = storiesOf('Styled Components/Basics', module)
+
+stories.add('Getting Started', () => {
+  // Create a Title component that'll render an <h1> tag with some styles
+  const Title = styled('h1')`
+    font-size: 1.5em;
+    text-align: center;
+    color: palevioletred;
+  `
+
+  // Create a Wrapper component that'll render a <section> tag with some styles
+  const Wrapper = styled('section')`
+    padding: 4em;
+    background: papayawhip;
+  `
+
+  return (
+    <Wrapper>
+      <Title>Hello World!</Title>
+    </Wrapper>
+  )
+})
+
+stories.add('Adapting based on props', () => {
+  const Button = styled('button')`
+    /* Adapt the colors based on primary prop */
+    background: ${props => (props.primary ? 'palevioletred' : 'white')};
+    color: ${props => (props.primary ? 'white' : 'palevioletred')};
+
+    font-size: 1em;
+    margin: 1em;
+    padding: 0.25em 1em;
+    border: 2px solid palevioletred;
+    border-radius: 3px;
+  `
+
+  return (
+    <div>
+      <Button>Normal</Button>
+      <Button primary>Primary</Button>
+    </div>
+  )
+})
+
+stories.add('Extending styles', () => {
+  // The Button from the last section without the interpolations
+  const Button = styled('button')`
+    color: palevioletred;
+    font-size: 1em;
+    margin: 1em;
+    padding: 0.25em 1em;
+    border: 2px solid palevioletred;
+    border-radius: 3px;
+  `
+
+  // A new component based on Button, but with some override styles
+  const TomatoButton = styled(Button)`
+    color: tomato;
+    border-color: tomato;
+  `
+
+  return (
+    <div>
+      <Button>Normal Button</Button>
+      <TomatoButton>Tomato Button</TomatoButton>
+    </div>
+  )
+})
+
+stories.add('Styling any components', () => {
+  // This could be react-router-dom's Link for example
+  const Link = ({className, children}) => (
+    <a className={className}>{children}</a>
+  )
+
+  const StyledLink = styled(Link)`
+    color: palevioletred;
+    font-weight: bold;
+  `
+
+  return (
+    <div>
+      <Link>Unstyled, boring Link</Link>
+      <br />
+      <StyledLink>Styled, exciting Link</StyledLink>
+    </div>
+  )
+})
+
+stories.add('Passed props', () => {
+  // Create an Input component that'll render an <input> tag with some styles
+  const Input = styled('input')`
+    padding: 0.5em;
+    margin: 0.5em;
+    color: ${props => props.inputColor || 'palevioletred'};
+    background: papayawhip;
+    border: none;
+    border-radius: 3px;
+  `
+
+  // Render a styled text input with the standard input color, and one with a custom input color
+  return (
+    <div>
+      <Input defaultValue="@probablyup" type="text" />
+      <Input defaultValue="@geelen" type="text" inputColor="rebeccapurple" />
+    </div>
+  )
+})
+
+stories.add('Pseudoelements, pseudoselectors, and nesting', () => {
+  const Thing = styled('button')`
+    color: blue;
+
+    ::before {
+      content: '🚀';
+    }
+
+    :hover {
+      color: red;
+    }
+  `
+
+  return <Thing>Hello world!</Thing>
+})
+
+stories.add('Complex Pseudoelements', () => {
+  const Thing = styled('div')`
+    color: blue;
+
+    &:hover {
+      color: red; // <Thing> when hovered
+    }
+
+    & ~ & {
+      background: tomato; // <Thing> as a sibling of <Thing>, but maybe not directly next to it
+    }
+
+    & + & {
+      background: lime; // <Thing> next to <Thing>
+    }
+
+    &.something {
+      background: orange; // <Thing> tagged with an additional CSS class ".something"
+    }
+
+    .something-else & {
+      border: 1px solid; // <Thing> inside another element labeled ".something-else"
+    }
+  `
+
+  Thing.defaultProps = {
+    tabIndex: 0,
+  }
+
+  return (
+    <p>
+      <Thing>Hello world!</Thing>
+      <Thing>How ya doing?</Thing>
+      <Thing className="something">The sun is shining...</Thing>
+      <div>Pretty nice day today.</div>
+      <Thing>Don't you think?</Thing>
+      <div className="something-else">
+        <Thing>Splendid.</Thing>
+      </div>
+    </p>
+  )
+})
+
+stories.add('Child className', () => {
+  const Thing = styled('div')`
+    color: blue;
+
+    .something {
+      border: 1px solid; // an element labeled ".something" inside <Thing>
+      display: block;
+    }
+  `
+
+  return (
+    <Thing>
+      <label htmlFor="foo-button" className="something">
+        Mystery button
+      </label>
+      <button id="foo-button">What do I do?</button>
+    </Thing>
+  )
+})
+
+stories.add('Attaching additional props', () => {
+  const Input = styled('input')`
+    color: palevioletred;
+    font-size: 1em;
+    border: 2px solid palevioletred;
+    border-radius: 3px;
+
+    /* here we use the dynamically computed props */
+    margin: ${props => props.margin};
+    padding: ${props => props.padding};
+  `
+
+  Input.defaultProps = {
+    type: 'password',
+    margin: props => props.size || '1em',
+    padding: props => props.size || '1em',
+  }
+
+  return (
+    <div>
+      <Input placeholder="A small text input" size="1em" />
+      <br />
+      <Input placeholder="A bigger text input" size="2em" />
+    </div>
+  )
+})
+
+stories.add('Animations', () => {
+  // keyframes returns a unique name based on a hash of the contents of the keyframes
+  const rotate360 = keyframes`
+    from {
+      transform: rotate(0deg);
+    }
+
+    to {
+      transform: rotate(360deg);
+    }
+  `
+
+  // Here we create a component that will rotate everything we pass in over two seconds
+  const Rotate = styled('div')`
+    display: inline-block;
+    animation: ${rotate360} 2s linear infinite;
+    padding: 2rem 1rem;
+    font-size: 1.2rem;
+  `
+
+  return <Rotate>&lt; 💅 &gt;</Rotate>
+})

--- a/stories/styled-components/02-advanced.stories.js
+++ b/stories/styled-components/02-advanced.stories.js
@@ -1,0 +1,184 @@
+import React from 'react'
+import {storiesOf} from '@storybook/react'
+import styled, {ThemeProvider} from '../../src/index'
+
+const stories = storiesOf('Styled Components/Advanced', module)
+
+stories.add('Theming', () => {
+  // Define our button, but with the use of props.theme this time
+  const Button = styled('button')`
+    font-size: 1em;
+    margin: 1em;
+    padding: 0.25em 1em;
+    border-radius: 3px;
+
+    /* Color the border and text with theme.main */
+    color: ${props => props.theme.main};
+    border: 2px solid ${props => props.theme.main};
+  `
+
+  // We are passing a default theme for Buttons that arent wrapped in the ThemeProvider
+  Button.defaultProps = {
+    theme: {
+      main: 'palevioletred',
+    },
+  }
+
+  // Define what props.theme will look like
+  const theme = {
+    main: 'mediumseagreen',
+  }
+
+  return (
+    <div>
+      <Button>Normal</Button>
+
+      <ThemeProvider theme={theme}>
+        <Button>Themed</Button>
+      </ThemeProvider>
+    </div>
+  )
+})
+
+stories.add('Function themes', () => {
+  // Define our button, but with the use of props.theme this time
+  const Button = styled('button')`
+    color: ${props => props.theme.fg};
+    border: 2px solid ${props => props.theme.fg};
+    background: ${props => props.theme.bg};
+
+    font-size: 1em;
+    margin: 1em;
+    padding: 0.25em 1em;
+    border-radius: 3px;
+  `
+
+  // Define our `fg` and `bg` on the theme
+  const theme = {
+    fg: 'palevioletred',
+    bg: 'white',
+  }
+
+  // This theme swaps `fg` and `bg`
+  const invertTheme = ({fg, bg}) => ({
+    fg: bg,
+    bg: fg,
+  })
+
+  return (
+    <ThemeProvider theme={theme}>
+      <div>
+        <Button>Default Theme</Button>
+
+        <ThemeProvider theme={invertTheme}>
+          <Button>Inverted Theme</Button>
+        </ThemeProvider>
+      </div>
+    </ThemeProvider>
+  )
+})
+
+stories.add('The theme prop', () => {
+  // Define our button
+  const Button = styled('button')`
+    font-size: 1em;
+    margin: 1em;
+    padding: 0.25em 1em;
+    border-radius: 3px;
+
+    /* Color the border and text with theme.main */
+    color: ${props => props.theme.main};
+    border: 2px solid ${props => props.theme.main};
+  `
+
+  // Define what main theme will look like
+  const theme = {
+    main: 'mediumseagreen',
+  }
+
+  return (
+    <div>
+      <Button theme={{main: 'royalblue'}}>Ad hoc theme</Button>
+      <ThemeProvider theme={theme}>
+        <div>
+          <Button>Themed</Button>
+          <Button theme={{main: 'darkorange'}}>Overidden</Button>
+        </div>
+      </ThemeProvider>
+    </div>
+  )
+})
+
+stories.add('Refs', () => {
+  const Input = styled('input')`
+    padding: 0.5em;
+    margin: 0.5em;
+    color: palevioletred;
+    background: papayawhip;
+    border: none;
+    border-radius: 3px;
+  `
+
+  class Form extends React.Component {
+    setInputRef = node => {
+      this.inputRef = node
+    }
+
+    handleOnMouseEnter = () => {
+      this.inputRef.focus()
+    }
+
+    handleOnMouseLeave = () => {
+      this.inputRef.blur()
+    }
+
+    render() {
+      return (
+        <Input
+          innerRef={this.setInputRef}
+          placeholder="Hover to focus!"
+          onMouseEnter={this.handleOnMouseEnter}
+          onMouseLeave={this.handleOnMouseLeave}
+        />
+      )
+    }
+  }
+
+  return <Form />
+})
+
+stories.add('Media Templates', () => {
+  const Content = styled('div')`
+    background: papayawhip;
+    height: 3em;
+    width: 3em;
+
+    @media (max-width: 700px) {
+      background: palevioletred;
+    }
+  `
+  return <Content />
+})
+
+stories.add('Style objects', () => {
+  // Static object
+  const Box = styled('div')({
+    background: 'palevioletred',
+    height: '50px',
+    width: '50px',
+  })
+
+  // Adapting based on props
+  const PropsBox = styled('div')(props => ({
+    background: props.background,
+    height: '50px',
+    width: '50px',
+  }))
+
+  return (
+    <div>
+      <Box />
+      <PropsBox background="blue" />
+    </div>
+  )
+})


### PR DESCRIPTION
## Theme custom prop

This update fixes the issue where a `theme` prop passed into the component
would be overridden by ThemeProvider.

The fix was to change the order of operations for supplying the theme prop to `styled`:

```
props.theme || (state !== null && state.theme) || {},
```

Storybook example below:

![screen shot 2018-10-14 at 12 32 10 pm](https://user-images.githubusercontent.com/2322354/46919431-404ed480-cfad-11e8-8985-d1438e4b00a7.jpg)


```jsx
stories.add('The theme prop', () => {
  // Define our button
  const Button = styled('button')`
    font-size: 1em;
    margin: 1em;
    padding: 0.25em 1em;
    border-radius: 3px;

    /* Color the border and text with theme.main */
    color: ${props => props.theme.main};
    border: 2px solid ${props => props.theme.main};
  `

  // Define what main theme will look like
  const theme = {
    main: 'mediumseagreen',
  }

  return (
    <div>
      <Button theme={{main: 'royalblue'}}>Ad hoc theme</Button>
      <ThemeProvider theme={theme}>
        <div>
          <Button>Themed</Button>
          <Button theme={{main: 'darkorange'}}>Overidden</Button>
        </div>
      </ThemeProvider>
    </div>
  )
})
```