### PR TITLE
FrameManager: Fix IE/Edge frame rendering

### DIFF
--- a/src/create-emotion-styled/createFrameManager.js
+++ b/src/create-emotion-styled/createFrameManager.js
@@ -17,28 +17,45 @@ export class FrameManager {
     return `__EMOTION_FRAMED_${this.frames.size}__`
   }
 
-  getEmotion(frame?: Frame): Object {
-    if (!frame) return {}
-
-    const index = this.getIndex(frame)
-
-    if (index >= 0) {
-      return this.emotionInstances[index]
-    }
-
+  createNewEmotionFromFrame(frame?: Frame): Object {
     const newEmotion = createEmotion(
       {
         [this.getEmotionNamespace()]: {},
       },
       {
         container: frame.head,
-      }
+      },
     )
 
     this.frames.add(frame)
     this.emotionInstances.push(newEmotion)
 
     return newEmotion
+  }
+
+  getEmotion(frame?: Frame): Object {
+    if (!frame) return {}
+
+    let emotionInstance
+
+    // This try/catch was added for IE11/Edge.
+    // These browsers throw an error if an attempt was made to on an iFrame
+    // that no longer exists (SCRIPT70 errors). This occurs when iFrames are
+    // unmounted/destroyed.
+    try {
+      const index = this.getIndex(frame)
+
+      if (index >= 0) {
+        emotionInstance = this.emotionInstances[index]
+      } else {
+        emotionInstance = this.createNewEmotionFromFrame(frame)
+      }
+    } catch (e) {
+      /* istanbul ignore next */
+      emotionInstance = this.createNewEmotionFromFrame(frame)
+    }
+
+    return emotionInstance
   }
 }
 

--- a/stories/FrameProvider.stories.js
+++ b/stories/FrameProvider.stories.js
@@ -1,22 +1,48 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
+import {storiesOf} from '@storybook/react'
 import Frame from 'react-frame-component'
-import { FrameProvider } from '../src'
+import {FrameProvider} from '../src'
 import ColorfulCards from './ColorfulCards'
 
 const stories = storiesOf('FrameProvider', module)
 
 stories.add('Example', () => {
-  return (
-    <div>
-      <p>This is an iFrame!</p>
-      <Frame>
-        <FrameProvider>
+  class Example extends React.Component {
+    state = {
+      showFrame: true,
+    }
+
+    toggleFrame = () => {
+      this.setState({
+        showFrame: !this.state.showFrame,
+      })
+    }
+
+    render() {
+      return (
+        <div>
+          <button onClick={this.toggleFrame}>Toggle Frame</button>
+          <p>This is an iFrame!</p>
+          {this.state.showFrame && (
+            <Frame height="300">
+              <h1>Frame 1</h1>
+              <FrameProvider>
+                <ColorfulCards />
+              </FrameProvider>
+            </Frame>
+          )}
+          <Frame height="300">
+            <h1>Frame 2</h1>
+            <FrameProvider>
+              <ColorfulCards />
+            </FrameProvider>
+          </Frame>
+          <p>Outside iFrame</p>
           <ColorfulCards />
-        </FrameProvider>
-      </Frame>
-      <p>Outside iFrame</p>
-      <ColorfulCards />
-    </div>
-  )
+        </div>
+      )
+    }
+  }
+
+  return <Example />
 })


### PR DESCRIPTION
## FrameManager: Fix IE/Edge frame rendering

![screen recording 2018-11-06 at 05 24 pm](https://user-images.githubusercontent.com/2322354/48097846-fb534200-e1e8-11e8-9d2c-c48048f01392.gif)

(GIF: Demo'ing Frame 1 being unmounted (destroy) and remounted in Edge. No errors in console. Stays are working)

This update fixes the iFrame `SCRIPT70` error that occurs in IE/Edge
when an iFrame unmounts/remounts.

The solution was to wrap the offending code in a `try/catch`.

The code in question is designed for performance, specifically to check
for cached instances of Emotion, and serves that instance instead of
creating a brand new one.

The caching mechanism will work for all browsers excluding IE/Edge, which
unfortunately, will create new emotion instances every time as unmounted
frames cannot be properly references.

Tested on Edge, IE, and Chrome