### PR TITLE
Update deps + getDocumentFromReactComponent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -281,57 +281,83 @@
       "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==",
       "dev": true
     },
-    "@helpscout/hsds-react": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@helpscout/hsds-react/-/hsds-react-2.0.0.tgz",
-      "integrity": "sha512-YYHn/D4GXdp90mP1NlBVgnmMFqWTEqjEPmvX8CTxWwXfYXAVr2mzQyKxxnzMWgnB1nDB0h5hkJkXChi2vave1g==",
+    "@helpscout/fancy": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-2.2.0.tgz",
+      "integrity": "sha512-s3o1d8AZOLtB0uqiRRMN7Nzyz24M/6rvH6Px8r9yk526pCm96Gza+4ozbMW1AblPSu4xgwx/z8xWj6KhWVrGUw==",
       "dev": true,
       "requires": {
-        "@helpscout/fancy": "^2.1.2",
+        "@emotion/hash": "^0.6.6",
+        "@emotion/memoize": "^0.6.6",
+        "@emotion/stylis": "^0.7.1",
+        "@emotion/unitless": "^0.6.7",
         "@helpscout/react-utils": "^1.0.1",
-        "@seedcss/seed-alert": "0.0.6",
+        "create-emotion": "9.2.12",
+        "create-emotion-styled": "9.2.8",
+        "csstype": "^2.5.7",
+        "emotion-theming": "9.2.9",
+        "prop-types": "15.6.2",
+        "stylis": "^3.5.3",
+        "stylis-rule-sheet": "^0.0.10"
+      }
+    },
+    "@helpscout/hsds-react": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@helpscout/hsds-react/-/hsds-react-2.5.6.tgz",
+      "integrity": "sha512-TPATZubOILazKQsZxJrw/eAACM6V8gRsdgsm2GsiJafw63x9a1flLpoQaaNvWOGXfUwHBjnuMj82rkZl3Who8g==",
+      "dev": true,
+      "requires": {
+        "@helpscout/fancy": "2.2.0",
+        "@helpscout/react-utils": "1.0.4",
+        "@helpscout/wedux": "0.0.10",
         "@seedcss/seed-button": "0.0.6",
         "@seedcss/seed-color-scheme": "0.0.6",
         "@seedcss/seed-control": "0.0.6",
         "@seedcss/seed-dash": "0.0.6",
         "@seedcss/seed-family": "0.0.6",
-        "@seedcss/seed-list": "0.0.6",
         "@seedcss/seed-this": "0.0.6",
-        "highlight.js": "^9.12.0",
-        "lodash.get": "^4.4.2",
-        "path-to-regexp": "^2.4.0",
-        "pluralize": "^7.0.0",
+        "compute-scroll-into-view": "1.0.11",
+        "dash-get": "1.0.0",
+        "fsevents": "2.0.1",
+        "highlight.js": "9.12.0",
+        "path-to-regexp": "2.4.0",
         "popper.js": "1.14.3",
-        "prop-types": "^15.6.1",
-        "react-sortable-hoc": "^0.6.7",
+        "prop-types": "^15",
+        "react-sortable-hoc": "0.6.7",
         "react-transition-group": "2.2.0"
       },
       "dependencies": {
-        "@helpscout/fancy": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/@helpscout/fancy/-/fancy-2.1.2.tgz",
-          "integrity": "sha512-yh0fwmFGzqPMv9Lzp7VEgkiNNI4b5IGG7SMPN8oJkjCTi5f4VsV1N/7DQp9T6IxMMJ4Dye9KMvHXBIHqI7N0nw==",
+        "@helpscout/react-utils": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@helpscout/react-utils/-/react-utils-1.0.4.tgz",
+          "integrity": "sha512-g6LVAAuZ0KVwy85zij+BB2wUTzrgWuH2sHmrGX9TiO4q2CPxOMyXLjbZfc4zRJkLXu7pEXSsQcqCmEqVjN7HZw==",
           "dev": true,
           "requires": {
-            "@emotion/hash": "^0.6.6",
-            "@emotion/memoize": "^0.6.6",
-            "@emotion/stylis": "^0.7.1",
-            "@emotion/unitless": "^0.6.7",
-            "@helpscout/react-utils": "^1.0.1",
-            "create-emotion": "9.2.12",
-            "create-emotion-styled": "9.2.8",
-            "csstype": "^2.5.7",
-            "emotion-theming": "9.2.9",
-            "prop-types": "15.6.2",
-            "stylis": "^3.5.3",
-            "stylis-rule-sheet": "^0.0.10"
+            "create-react-context": "0.2.2",
+            "hoist-non-react-statics": "3.0.1"
           }
         },
-        "lodash.get": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-          "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+        "dash-get": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/dash-get/-/dash-get-1.0.0.tgz",
+          "integrity": "sha512-6a2n1Ejyj/38/zODDYkypCf1cvhUCM6VFWeA+kNm2rzPhjeR5rgLb4G9ZfkoB11vLHWRQ+1p45w3RiMUTi9T+w==",
           "dev": true
+        },
+        "fsevents": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.1.tgz",
+          "integrity": "sha512-p+CXqK/iLvDESUWdn3NA3JVO9HxdfI+iXx8xR3DqWgKZvQNiEVpAyUQo0lmwz8rqksb4xaGerG291xuwwhX2kA==",
+          "dev": true,
+          "optional": true
+        },
+        "hoist-non-react-statics": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.0.1.tgz",
+          "integrity": "sha512-1kXwPsOi0OGQIZNVMPvgWJ9tSnGMiMfJdihqEzrPEXlHOBh9AAHXX/QYmAJTXztnz/K+PQ8ryCb4eGaN6HlGbQ==",
+          "dev": true,
+          "requires": {
+            "react-is": "^16.3.2"
+          }
         },
         "path-to-regexp": {
           "version": "2.4.0",
@@ -356,11 +382,12 @@
       }
     },
     "@helpscout/react-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@helpscout/react-utils/-/react-utils-1.0.1.tgz",
-      "integrity": "sha512-pVIlhPmHyNK5lkiCnTlA/3JpnAaZ2kbeRIdmdriC2UNLvYk8Utx9Tbl4bqcP/YsL52X6xPEPOue7FJlOANbG7Q==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@helpscout/react-utils/-/react-utils-1.0.5.tgz",
+      "integrity": "sha512-EvrDjlvNubV0YfWu/XtQW0VZppPKzDH/gD0f2oYs7y1NlNJe1KrACMYT7pIPZt2H/iRi3XU9W42egfnj4rfvrQ==",
       "requires": {
         "create-react-context": "0.2.2",
+        "dash-get": "1.0.1",
         "hoist-non-react-statics": "3.0.1"
       },
       "dependencies": {
@@ -373,6 +400,12 @@
           }
         }
       }
+    },
+    "@helpscout/wedux": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@helpscout/wedux/-/wedux-0.0.10.tgz",
+      "integrity": "sha512-SM42jv0QUkG7vOP9BvG04F4uD3o9n8B4YJg7qF+HONMNXzx0NggJkZsxmCjc1IjLVb1ergYKqP/FsFr5Cra+7Q==",
+      "dev": true
     },
     "@helpscout/zero": {
       "version": "0.0.9",
@@ -431,32 +464,6 @@
         "any-observable": "^0.3.0"
       }
     },
-    "@seedcss/seed-alert": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@seedcss/seed-alert/-/seed-alert-0.0.6.tgz",
-      "integrity": "sha512-K7xuHDHX11g/N7yLXOM1Tsq7CK59z1C7XE8KBuhiSNDbqy9f2xKysEeIvEzoZcAcycn/JW7PoMzLSlbNsBg9MA==",
-      "dev": true,
-      "requires": {
-        "@seedcss/seed-badge": "^0.0.6",
-        "@seedcss/seed-button": "^0.0.6",
-        "@seedcss/seed-dash": "^0.0.6",
-        "@seedcss/seed-publish": "^0.0.6",
-        "@seedcss/seed-states": "^0.0.6",
-        "sass-pathfinder": "0.0.5"
-      }
-    },
-    "@seedcss/seed-badge": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@seedcss/seed-badge/-/seed-badge-0.0.6.tgz",
-      "integrity": "sha512-0kgdsxs06JvMX7PEGN5MTj6+5JZbyJY69GuN6PdLylH+2hUqThqFP8/hIquyXUHaFsRoVuwnX8Ak+hvLxHJTCg==",
-      "dev": true,
-      "requires": {
-        "@seedcss/seed-dash": "^0.0.6",
-        "@seedcss/seed-publish": "^0.0.6",
-        "@seedcss/seed-states": "^0.0.6",
-        "sass-pathfinder": "0.0.5"
-      }
-    },
     "@seedcss/seed-border": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@seedcss/seed-border/-/seed-border-0.0.6.tgz",
@@ -501,15 +508,6 @@
         "sass-pathfinder": "0.0.5"
       }
     },
-    "@seedcss/seed-color-scheme-helpscout": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@seedcss/seed-color-scheme-helpscout/-/seed-color-scheme-helpscout-0.0.6.tgz",
-      "integrity": "sha512-xFUke/8I9skBShpW4SKGAwGJmQnSXGpcqkRrEUHBDze5rLJf6X+cZQNMc+Wcv0c6Wso44Mtc109LJAsj8cwNew==",
-      "dev": true,
-      "requires": {
-        "@seedcss/seed-color-scheme": "^0.0.6"
-      }
-    },
     "@seedcss/seed-config": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@seedcss/seed-config/-/seed-config-0.0.6.tgz",
@@ -541,17 +539,6 @@
       "integrity": "sha512-Me5ZFOuVX3IY28IETM0fEvuqOxM9x2XOLBbhWU189YcB3ivFjOjpLtCLRCBT/9oM3ZRmaLWxPFTwfq6wsvbC5g==",
       "dev": true
     },
-    "@seedcss/seed-list": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@seedcss/seed-list/-/seed-list-0.0.6.tgz",
-      "integrity": "sha512-dXvA4/275IJ1xiFCE3C2A3M3Rp6F0OvI6T+BshKP1rYgxU4By0vuv1Qled43pG41O/XyO1svaMnvNgrmy0OC/g==",
-      "dev": true,
-      "requires": {
-        "@seedcss/seed-border": "^0.0.6",
-        "@seedcss/seed-breakpoints": "^0.0.6",
-        "@seedcss/seed-publish": "^0.0.6"
-      }
-    },
     "@seedcss/seed-props": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@seedcss/seed-props/-/seed-props-0.0.6.tgz",
@@ -563,18 +550,6 @@
       "resolved": "https://registry.npmjs.org/@seedcss/seed-publish/-/seed-publish-0.0.6.tgz",
       "integrity": "sha512-xKg58QaIqIxTNjwEoZt52MM5OWFK87k0879/QYykui/gMJSiwYKCLmtDI7ZN680p2JIbV6bu/4F79V4XGQE4Cw==",
       "dev": true
-    },
-    "@seedcss/seed-states": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@seedcss/seed-states/-/seed-states-0.0.6.tgz",
-      "integrity": "sha512-YfvIdVLAFHmYu3Z4Zw0bFoi0H2RTgS4FpfjOiJ5HN3DVMjN7xxLTRIiwgBopUZ+D/tYvvs5KK6ORmPHGzz2sgQ==",
-      "dev": true,
-      "requires": {
-        "@seedcss/seed-color-scheme": "^0.0.6",
-        "@seedcss/seed-color-scheme-helpscout": "^0.0.6",
-        "@seedcss/seed-dash": "^0.0.6",
-        "sass-pathfinder": "0.0.5"
-      }
     },
     "@seedcss/seed-this": {
       "version": "0.0.6",
@@ -1562,7 +1537,7 @@
       "dependencies": {
         "hoist-non-react-statics": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
           "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=",
           "dev": true
         }
@@ -2119,7 +2094,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -4167,7 +4142,7 @@
     },
     "bindings": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
       "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
       "dev": true
     },
@@ -4200,7 +4175,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -4600,7 +4575,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -5159,7 +5134,7 @@
     },
     "color-string": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "dev": true,
       "requires": {
@@ -5179,7 +5154,7 @@
     },
     "colors": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
@@ -5262,6 +5237,12 @@
         }
       }
     },
+    "compute-scroll-into-view": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.11.tgz",
+      "integrity": "sha512-uUnglJowSe0IPmWOdDtrlHXof5CTIJitfJEyITHBW6zDVOGu9Pjk5puaLM73SLcwak0L4hEjO7Td88/a6P5i7A==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5321,7 +5302,7 @@
         },
         "commander": {
           "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
           "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
           "dev": true
         },
@@ -6023,6 +6004,11 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
       "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
       "dev": true
+    },
+    "dash-get": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dash-get/-/dash-get-1.0.1.tgz",
+      "integrity": "sha512-XxVQ5FDVkfHyKrGBSXeRN9QmkqxUAgiOPXLgPDkGfmOd231OSGDfTEbMoH9DQEjGgse9HvMeg9IvQKcGaGC+iw=="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -7281,7 +7267,7 @@
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -7577,7 +7563,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -8859,7 +8845,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -9128,7 +9114,7 @@
     },
     "handle-thing": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+      "resolved": "http://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
       "dev": true
     },
@@ -11676,7 +11662,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         },
@@ -12492,7 +12478,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -12675,7 +12661,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
@@ -13658,7 +13644,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -16385,7 +16371,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -16400,7 +16386,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -16612,7 +16598,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -16683,7 +16669,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -16743,7 +16729,7 @@
     },
     "popper.js": {
       "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.3.tgz",
+      "resolved": "http://registry.npmjs.org/popper.js/-/popper.js-1.14.3.tgz",
       "integrity": "sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU=",
       "dev": true
     },
@@ -16760,7 +16746,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         }
@@ -18082,7 +18068,7 @@
     },
     "pretty-bytes": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
       "dev": true
     },
@@ -18189,6 +18175,7 @@
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
       "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
@@ -18632,9 +18619,9 @@
       }
     },
     "react-is": {
-      "version": "16.5.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.5.2.tgz",
-      "integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ=="
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.7.0.tgz",
+      "integrity": "sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -18771,7 +18758,7 @@
         },
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         },
@@ -18934,7 +18921,7 @@
             },
             "doctrine": {
               "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+              "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
               "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
               "dev": true,
               "requires": {
@@ -19516,9 +19503,9 @@
       }
     },
     "react-sortable-hoc": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-0.6.8.tgz",
-      "integrity": "sha512-sUUAtNdV84AKZ2o+F5lVOOFWcyWG6aGDkNFgHoieB1zFLeWLWENkix06asPS4/GhigfuRh06aZix1j3Qx8+NSQ==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-0.6.7.tgz",
+      "integrity": "sha1-4w0ke8Nt1aYFQwwzGsnLUKX6cqY=",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.11.6",
@@ -19893,7 +19880,7 @@
     },
     "regjsparser": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
@@ -19902,7 +19889,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -20097,7 +20084,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -20250,7 +20237,7 @@
       "dependencies": {
         "estree-walker": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
           "integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
           "dev": true
         },
@@ -21232,7 +21219,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
@@ -21395,7 +21382,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "url": "https://github.com/helpscout/fancy/issues"
   },
   "keywords": [
-    "awesomecss",
     "components",
     "css",
     "css-in-js",
@@ -43,7 +42,6 @@
     "fancy",
     "helpscout",
     "react",
-    "styled",
     "styled",
     "styled-components"
   ],
@@ -54,21 +52,20 @@
     "react": "^16 || ^15"
   },
   "dependencies": {
-    "@emotion/hash": "^0.6.6",
-    "@emotion/memoize": "^0.6.6",
-    "@emotion/stylis": "^0.7.1",
-    "@emotion/unitless": "^0.6.7",
-    "@helpscout/react-utils": "^1.0.1",
+    "@emotion/hash": "0.6.6",
+    "@emotion/memoize": "0.6.6",
+    "@emotion/stylis": "0.7.1",
+    "@emotion/unitless": "0.6.7",
+    "@helpscout/react-utils": "1.0.5",
     "create-emotion": "9.2.12",
     "create-emotion-styled": "9.2.8",
-    "csstype": "^2.5.7",
+    "csstype": "2.5.7",
     "emotion-theming": "9.2.9",
-    "prop-types": "15.6.2",
-    "stylis": "^3.5.3",
-    "stylis-rule-sheet": "^0.0.10"
+    "stylis": "3.5.3",
+    "stylis-rule-sheet": "0.0.10"
   },
   "devDependencies": {
-    "@helpscout/hsds-react": "^2.0.0",
+    "@helpscout/hsds-react": "^2.5.6",
     "@helpscout/zero": "^0.0.9",
     "@storybook/addon-actions": "^3.4.3",
     "@storybook/addon-links": "^3.4.3",

--- a/src/FrameProvider/utils.js
+++ b/src/FrameProvider/utils.js
@@ -1,11 +1,10 @@
 // @flow
-import PropTypes from 'prop-types'
 import channel from './channel'
 
 export const contextTypes = {
-  [channel]: PropTypes.object,
+  [channel]: () => undefined,
 }
 
-export { default as channel } from './channel'
-export { default as createBroadcast } from './createBroadcast'
+export {default as channel} from './channel'
+export {default as createBroadcast} from './createBroadcast'
 export type Frame = Object

--- a/src/ScopeProvider/ScopeProvider.js
+++ b/src/ScopeProvider/ScopeProvider.js
@@ -1,6 +1,5 @@
 // @flow
 import React, {Component, Children, type Node as ReactNode} from 'react'
-import PropTypes from 'prop-types'
 import channel from './channel'
 
 type Props = {
@@ -9,7 +8,7 @@ type Props = {
 }
 
 export const contextTypes = {
-  [channel]: PropTypes.object,
+  [channel]: () => undefined,
 }
 
 class ScopeProvider extends Component<Props> {

--- a/src/create-emotion-styled/index.js
+++ b/src/create-emotion-styled/index.js
@@ -1,5 +1,4 @@
 // @flow
-import PropTypes from 'prop-types'
 import type {ElementType} from 'react'
 import typeof ReactType from 'react'
 import type {CreateStyled, StyledOptions} from './utils'
@@ -19,9 +18,9 @@ import {channel as frameChannel} from '../FrameProvider'
 import {channel as scopeChannel} from '../ScopeProvider'
 
 const contextTypes = {
-  [channel]: PropTypes.object,
-  [frameChannel]: PropTypes.object,
-  [scopeChannel]: PropTypes.object,
+  [channel]: () => undefined,
+  [frameChannel]: () => undefined,
+  [scopeChannel]: () => undefined,
 }
 
 const defaultProps = {

--- a/src/utils/__tests__/getDocumentFromReactComponent.test.js
+++ b/src/utils/__tests__/getDocumentFromReactComponent.test.js
@@ -12,7 +12,7 @@ describe('getDocumentFromReactComponent', () => {
   })
 
   test('Supports React v16.x', () => {
-    const mockDocument = 0
+    const mockDocument = 1
     // Naive assumption of React.Component internals.
     // Works as of v16.3.x
     const component = {
@@ -30,7 +30,7 @@ describe('getDocumentFromReactComponent', () => {
   })
 
   test('Supports React v15.x', () => {
-    const mockDocument = 0
+    const mockDocument = 1
     // Naive assumption of React.Component internals.
     // Works as of v15.6.x
     const component = {

--- a/src/utils/getDocumentFromReactComponent.js
+++ b/src/utils/getDocumentFromReactComponent.js
@@ -1,30 +1,3 @@
-// @flow
-/**
- * Retrieves the document where the React Component has been
- * mounted to.
- *
- * @param   {React.Component} Component A React.Component.
- * @returns {document} The closest document.
- */
-function getDocumentFromReactComponent(Component: Object): Document {
-  if (!Component || typeof Component !== 'object') return document
+import getDocumentFromComponent from '@helpscout/react-utils/dist/getDocumentFromComponent'
 
-  // React 16.x
-  if (Component._reactInternalFiber) {
-    return (
-      Component._reactInternalFiber.return &&
-      Component._reactInternalFiber.return.stateNode &&
-      Component._reactInternalFiber.return.stateNode.ownerDocument
-    )
-    // React 15.x
-  } else if (Component._reactInternalInstance) {
-    return (
-      Component._reactInternalInstance._context &&
-      Component._reactInternalInstance._context.document
-    )
-  } else {
-    return document
-  }
-}
-
-export default getDocumentFromReactComponent
+export default getDocumentFromComponent


### PR DESCRIPTION
## Update deps + getDocumentFromReactComponent

This update removes PropTypes as a dependency and adjusts dependency versions to
use exact numbers, instead of `^`.

It also updates the getDocumentFromReactComponent util to use the one provided
by `react-utils`, which has the latest support for React 16.6+