### PR TITLE
Change data-cy to data-cy-styled. Add displayLabel for namespacing

### DIFF
--- a/src/create-emotion-styled/index.js
+++ b/src/create-emotion-styled/index.js
@@ -245,7 +245,7 @@ function createEmotionStyled(
             // $FlowFixMe
             pickAssign(shouldForwardProp, {}, props, {
               className,
-              'data-cy': createDataCy(props, baseTag),
+              'data-cy-styled': createDataCy(props, baseTag),
               ref: props.innerRef,
             }),
           )

--- a/src/create-emotion-styled/utils.js
+++ b/src/create-emotion-styled/utils.js
@@ -5,11 +5,11 @@ import type { Interpolations } from 'create-emotion'
 export const themeChannel = '__EMOTION_THEMING__'
 
 export const getDisplayName = Component =>
-  Component.displayName || Component.name
+  Component.displayLabel || Component.displayName || Component.name
 
 export const createDataCy = (props, Component) => {
-  if (props['data-cy']) {
-    return props['data-cy']
+  if (props['data-cy-styled']) {
+    return props['data-cy-styled']
   }
 
   return getDisplayName(Component)

--- a/src/styled/__tests__/styled.test.js
+++ b/src/styled/__tests__/styled.test.js
@@ -143,10 +143,25 @@ describe('styled', () => {
       expect(el.classList.toString()).toContain('custom')
       expect(el.classList.toString()).toContain('SomeBase')
     })
+
+    test('Autogenerates a hashed className with component displayLabel', () => {
+      const SomeBase = props => <span {...props} />
+      SomeBase.displayLabel = 'DoubleBass'
+
+      const Compo = styled(SomeBase)(`
+        display: block;
+      `)
+      const wrapper = mount(<Compo className="custom" />)
+      const el = wrapper.find('span').getNode()
+
+      expect(el.classList.toString()).toContain('css-')
+      expect(el.classList.toString()).toContain('custom')
+      expect(el.classList.toString()).toContain('DoubleBass')
+    })
   })
 
   describe('data attribute', () => {
-    test('Autogenerates a data-cy attribute, if applicable', () => {
+    test('Autogenerates a data-cy-styled attribute, if applicable', () => {
       const BaseCompo = props => <span {...props} />
       BaseCompo.displayName = 'Compo'
       const Compo = styled(BaseCompo)(`
@@ -156,10 +171,10 @@ describe('styled', () => {
       const wrapper = mount(<Compo />)
       const el = wrapper.find('span')
 
-      expect(el.prop('data-cy')).toBe('Compo')
+      expect(el.prop('data-cy-styled')).toBe('Compo')
     })
 
-    test('Does not add data-cy if creating a baseTag', () => {
+    test('Does not add data-cy-styled if creating a baseTag', () => {
       const Compo = styled('span')(`
         display: block;
       `)
@@ -167,7 +182,7 @@ describe('styled', () => {
       const wrapper = mount(<Compo />)
       const el = wrapper.find('span')
 
-      expect(el.prop('data-cy')).toBeFalsy()
+      expect(el.prop('data-cy-styled')).toBeFalsy()
     })
 
     test('Attempts to use name if displayName is not available', () => {
@@ -180,7 +195,7 @@ describe('styled', () => {
       const wrapper = mount(<Compo className="test a b c" />)
       const el = wrapper.find('span')
 
-      expect(el.prop('data-cy')).toBe('BaseCompo')
+      expect(el.prop('data-cy-styled')).toBe('BaseCompo')
     })
   })
 


### PR DESCRIPTION
## Change data-cy to data-cy-styled. Add displayLabel for namespacing

This update changes the auto-generated `data-cy` to `data-cy-styled` to
reduce conflict with the HOC from HSDS: React.

The Styled Component generator is now paying attention to a special
static property (`displayLabel`), which can customize the autogenerated
className + data-cy-styled results. This borrows the `label` convention
introduced in Emotion 10.

##### Example

```jsx
const MyComponent = () => <div />
MyComponent.displayLabel = 'hello'

const StyledComponent = styled(MyComponent)()

// Autogenerated CSS className will be something like
// .css-1jjidj3-hello
```