### PR TITLE
createStyled: Export and add extraArguments feature

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,6 +11,7 @@ import styled, {
   FrameProvider,
   ScopeProvider,
   ThemeProvider,
+  createStyled,
   // Everything below comes from Emotion
   flush,
   hydrate,
@@ -28,7 +29,6 @@ import styled, {
 
 ## See also
 
-* [iFrames](iframes.md)
-* [Scoping](scoping.md)
-* [Theming](theming.md)
-
+- [iFrames](iframes.md)
+- [Scoping](scoping.md)
+- [Theming](theming.md)

--- a/src/__tests__/fancy.test.js
+++ b/src/__tests__/fancy.test.js
@@ -1,6 +1,11 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import styled, { FrameProvider, ScopeProvider, ThemeProvider } from '../index'
+import styled, {
+  createStyled,
+  FrameProvider,
+  ScopeProvider,
+  ThemeProvider,
+} from '../index'
 import { getStyleProp, resetStyleTags } from '../utils/testHelpers'
 
 describe('Fancy', () => {
@@ -26,7 +31,7 @@ describe('Fancy', () => {
     const wrapper = mount(
       <FrameProvider>
         <Compo />
-      </FrameProvider>
+      </FrameProvider>,
     )
     const el = wrapper.find('span').getNode()
 
@@ -43,7 +48,7 @@ describe('Fancy', () => {
         <div id="app">
           <Compo />
         </div>
-      </ScopeProvider>
+      </ScopeProvider>,
     )
     const el = wrapper.find('span').getNode()
 
@@ -61,7 +66,7 @@ describe('Fancy', () => {
     const wrapper = mount(
       <ThemeProvider theme={theme}>
         <Compo />
-      </ThemeProvider>
+      </ThemeProvider>,
     )
     wrapper.setProps({
       theme: {
@@ -71,5 +76,27 @@ describe('Fancy', () => {
     const el = wrapper.find('span').getNode()
 
     expect(getStyleProp(el, 'color')).toBe('red')
+  })
+
+  test('Correctly exports createStyled', () => {
+    const extraArguments = {
+      $color: 'red',
+      $theme: {
+        colors: {
+          primary: 'blue',
+        },
+      },
+    }
+    const Comp = createStyled({ extraArguments })('div')(
+      ({ $color, $theme }) => `
+      background: ${$theme.colors.primary};
+      color: ${$color};
+    `,
+    )
+    const wrapper = mount(<Comp />)
+    const el = wrapper.find('div').getNode()
+
+    expect(getStyleProp(el, 'color')).toBe('red')
+    expect(getStyleProp(el, 'background')).toBe('blue')
   })
 })

--- a/src/create-emotion-styled/index.js
+++ b/src/create-emotion-styled/index.js
@@ -28,14 +28,27 @@ const defaultProps = {
   pure: true,
 }
 
+const defaultOptions = {
+  extraArguments: {},
+  pure: true,
+}
+
 function createEmotionStyled(
   emotion: Object,
   view: ReactType,
-  options: Object,
+  options: Object = defaultOptions,
 ) {
+  // This allows for the user to create their own styled() function with
+  // built-in extras.
+  // This is a custom Fancy addition. The idea was inspired by Styletron and
+  // isn't part of Emotion.
+  // https://baseweb.design/getting-started/installation/#styletron
+  const { pure: createPure, extraArguments } = { ...defaultOptions, ...options }
+
   let createStyled: CreateStyled = (tag, options) => {
-    // Custom Fancy, non-Emotion default options
-    const { pure } = { ...defaultProps, ...options }
+    // Custom Fancy, non-Emotion default props/options
+    const { pure: optionsPure } = { ...defaultProps, ...options }
+    const pure = createPure || optionsPure
 
     if (process.env.NODE_ENV !== 'production') {
       if (tag === undefined) {
@@ -182,9 +195,15 @@ function createEmotionStyled(
         }
         render() {
           const { props, state } = this
-          this.mergedProps = pickAssign(testAlwaysTrue, {}, props, {
-            theme: props.theme || (state !== null && state.theme) || {},
-          })
+          this.mergedProps = pickAssign(
+            testAlwaysTrue,
+            {},
+            props,
+            extraArguments,
+            {
+              theme: props.theme || (state !== null && state.theme) || {},
+            },
+          )
 
           let className = ''
           let classInterpolations = []

--- a/src/create-styled/__tests__/create-styled.test.js
+++ b/src/create-styled/__tests__/create-styled.test.js
@@ -1,6 +1,11 @@
 import React from 'react'
-import {mount} from 'enzyme'
+import { mount } from 'enzyme'
 import createStyled from '../index'
+import { getStyleProp, resetStyleTags } from '../../utils/testHelpers'
+
+afterEach(() => {
+  resetStyleTags()
+})
 
 test('Creates a React.PureComponent instance, by default', () => {
   const Comp = createStyled()('div')``
@@ -11,7 +16,7 @@ test('Creates a React.PureComponent instance, by default', () => {
 })
 
 test('Can create a React.Component instance, if defined', () => {
-  const Comp = createStyled({pure: false})('div')``
+  const Comp = createStyled({ pure: false })('div')``
   const wrapper = mount(<Comp />)
   const el = wrapper.getNodes()[0]
 
@@ -19,9 +24,31 @@ test('Can create a React.Component instance, if defined', () => {
 })
 
 test('Can create a React.PureComponent instance, if defined', () => {
-  const Comp = createStyled({pure: true})('div')``
+  const Comp = createStyled({ pure: true })('div')``
   const wrapper = mount(<Comp />)
   const el = wrapper.getNodes()[0]
 
   expect(el instanceof React.PureComponent).toBe(true)
+})
+
+test('Can create styled with extra arguments', () => {
+  const extraArguments = {
+    $color: 'red',
+    $theme: {
+      colors: {
+        primary: 'blue',
+      },
+    },
+  }
+  const Comp = createStyled({ extraArguments })('div')(
+    ({ $color, $theme }) => `
+    background: ${$theme.colors.primary};
+    color: ${$color};
+  `,
+  )
+  const wrapper = mount(<Comp />)
+  const el = wrapper.find('div').getNode()
+
+  expect(getStyleProp(el, 'color')).toBe('red')
+  expect(getStyleProp(el, 'background')).toBe('blue')
 })

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,14 @@
 import styled from './styled/index'
-import FrameProvider from './FrameProvider/index'
-import ScopeProvider from './ScopeProvider/index'
-import ThemeProvider from './ThemeProvider/index'
 
-export default styled
+// Providers
+export { default as FrameProvider } from './FrameProvider/index'
+export { default as ScopeProvider } from './ScopeProvider/index'
+export { default as ThemeProvider } from './ThemeProvider/index'
 
+// Factories
+export { default as createStyled } from './create-styled/index'
+
+// Library
 export * from './emotion/index'
 
-export { FrameProvider, ScopeProvider, ThemeProvider }
+export default styled


### PR DESCRIPTION
## createStyled: Export and add extraArguments feature

This update exports the `createStyled` factory function, which is used
to create the primary `styled()` styled component function.

`createStyled` was enhanced with a special argument called `extraArguments`.
This allows for a creation of `styled()` with unique + convenient built-in
props. By default, only `theme` is provided to the styled component.


#### Example

```js
import { createStyled } from '@helpscout/fancy'

const extraArguments = {
  $branding: {
    main: '#00ff55'
  }
}
const styled = createStyled({ extraArguments })
```

From this point on, any component created with `styled` will have access to `$branding`.

```js
const Block = styled('div')`
  $({ $branding }) => `
    color: ${$branding.main};
  `
`
```

Anything can be passed as `extraArguments`. Other handing things can include functions like `rgba` or font utils.

### Inspiration:

https://github.com/reduxjs/redux-thunk#injecting-a-custom-argument

And

https://baseweb.design/getting-started/installation/#styletron