### PR TITLE
Styled: Add ability to support certain static props

### DIFF
--- a/src/create-emotion-styled/index.js
+++ b/src/create-emotion-styled/index.js
@@ -316,6 +316,11 @@ function createEmotionStyled(
     createStyled = new Proxy(createStyled, {
       get(target, property) {
         switch (property) {
+          // Extras
+          case '$$':
+          case '$':
+          case '__':
+          case '_':
           // react-hot-loader tries to access this stuff
           case '__proto__':
           case 'name':

--- a/src/styled/__tests__/styled.test.js
+++ b/src/styled/__tests__/styled.test.js
@@ -417,4 +417,54 @@ describe('styled', () => {
       expect(getStyleProp(fancyNode, 'color')).toBe('red')
     })
   })
+
+  describe('Extras', () => {
+    test('Can store static under _', () => {
+      styled._ = { display: 'flex' }
+      const Component = styled('div')`
+        display: ${styled._.display};
+      `
+
+      const wrapper = mount(<Component />)
+      const node = wrapper.getDOMNode()
+
+      expect(getStyleProp(node, 'display')).toBe('flex')
+    })
+
+    test('Can store static under __', () => {
+      styled.__ = { display: 'flex' }
+      const Component = styled('div')`
+        display: ${styled.__.display};
+      `
+
+      const wrapper = mount(<Component />)
+      const node = wrapper.getDOMNode()
+
+      expect(getStyleProp(node, 'display')).toBe('flex')
+    })
+
+    test('Can store static under $', () => {
+      styled.$ = { display: 'flex' }
+      const Component = styled('div')`
+        display: ${styled.$.display};
+      `
+
+      const wrapper = mount(<Component />)
+      const node = wrapper.getDOMNode()
+
+      expect(getStyleProp(node, 'display')).toBe('flex')
+    })
+
+    test('Can store static under $$', () => {
+      styled.$$ = { display: 'flex' }
+      const Component = styled('div')`
+        display: ${styled.$$.display};
+      `
+
+      const wrapper = mount(<Component />)
+      const node = wrapper.getDOMNode()
+
+      expect(getStyleProp(node, 'display')).toBe('flex')
+    })
+  })
 })


### PR DESCRIPTION
## Styled: Add ability to support certain static props

This update allows for the ability to add certain static properties to
`styled`. This enables the storage of "extra" properties, allowing for
a easier way to share utilties/values when creating styled components.