### PR TITLE
COMMS-234: Added 'key' attribute to Emotion instance created by FrameManager

### DIFF
--- a/src/create-emotion-styled/createFrameManager.js
+++ b/src/create-emotion-styled/createFrameManager.js
@@ -24,6 +24,7 @@ export class FrameManager {
       },
       {
         container: frame.head,
+        key: 'fancy',
       },
     )
 


### PR DESCRIPTION
**[Jira Issue](https://helpscout.atlassian.net/browse/COMMS-234)**

## Problem

Fancy (Emotion) styles inside an iframe were conflicting with those of the host page, so if the host page was also using Emotion, the iframe styles would overwrite them. Since we use Fancy styles in the Beacon embed iframes, embedding it on a page that uses Emotion triggers this issue.

**[👉 Here's a short video showing this issue](https://share.getcloudapp.com/YEu8WeQ0)**

## Solution

To prevent conflicts, Emotion recommends that you create a new "Emotion instance" when working with iframes, via the `createEmotion` function. We were already doing this, but we were failing to give this instance a unique "key" so that Emotion could see that we were targeting two different documents. This key is then added as the `data-emotion` attribute of the generated style tags, and prevents the styles from conflicting with each other:

![Demo](https://p-zkf42x.t2.n0.cdn.getcloudapp.com/items/d5uzngKR/Image+2019-08-28+at+3.51.01+PM.png?v=8428ce242e895a338d4e5dc57a80ed93)

**[👉 Here's a short video showing the fix](https://share.getcloudapp.com/JruX8pDA)**

## Impact

Since we're adding the key just to the `createEmotion` instance that handles iframes, it should only impact products (like Beacon) that use Fancy in this way. Other products like hsds-react should not be impacted by this change (but we should test there either way).